### PR TITLE
Display token usage for each turn

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -409,7 +409,7 @@ func (a *agent) processGeneration(ctx context.Context, sessionID, content string
 		agentMessage, toolResults, err := a.streamAndHandleEvents(ctx, sessionID, msgHistory)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				agentMessage.AddFinish(message.FinishReasonCanceled, "Request cancelled", "")
+				agentMessage.AddFinish(message.FinishReasonCanceled, "Request cancelled", "", nil, 0)
 				a.messages.Update(context.Background(), agentMessage)
 				return a.err(ErrRequestCancelled)
 			}
@@ -425,7 +425,7 @@ func (a *agent) processGeneration(ctx context.Context, sessionID, content string
 		}
 		if agentMessage.FinishReason() == "" {
 			// Kujtim: could not track down where this is happening but this means its cancelled
-			agentMessage.AddFinish(message.FinishReasonCanceled, "Request cancelled", "")
+			agentMessage.AddFinish(message.FinishReasonCanceled, "Request cancelled", "", nil, 0)
 			_ = a.messages.Update(context.Background(), agentMessage)
 			return a.err(ErrRequestCancelled)
 		}
@@ -598,7 +598,7 @@ out:
 }
 
 func (a *agent) finishMessage(ctx context.Context, msg *message.Message, finishReason message.FinishReason, message, details string) {
-	msg.AddFinish(finishReason, message, details)
+	msg.AddFinish(finishReason, message, details, nil, 0)
 	_ = a.messages.Update(ctx, *msg)
 }
 
@@ -638,20 +638,30 @@ func (a *agent) processEvent(ctx context.Context, sessionID string, assistantMsg
 	case provider.EventComplete:
 		assistantMsg.FinishThinking()
 		assistantMsg.SetToolCalls(event.Response.ToolCalls)
-		assistantMsg.AddFinish(event.Response.FinishReason, "", "")
+		cost, err := a.TrackUsage(ctx, sessionID, a.Model(), event.Response.Usage)
+		if err != nil {
+			return err
+		}
+		usage := message.TokenUsage{
+			InputTokens:         event.Response.Usage.InputTokens,
+			OutputTokens:        event.Response.Usage.OutputTokens,
+			CacheCreationTokens: event.Response.Usage.CacheCreationTokens,
+			CacheReadTokens:     event.Response.Usage.CacheReadTokens,
+		}
+		assistantMsg.AddFinish(event.Response.FinishReason, "", "", &usage, cost)
 		if err := a.messages.Update(ctx, *assistantMsg); err != nil {
 			return fmt.Errorf("failed to update message: %w", err)
 		}
-		return a.TrackUsage(ctx, sessionID, a.Model(), event.Response.Usage)
+		return nil
 	}
 
 	return nil
 }
 
-func (a *agent) TrackUsage(ctx context.Context, sessionID string, model catwalk.Model, usage provider.TokenUsage) error {
+func (a *agent) TrackUsage(ctx context.Context, sessionID string, model catwalk.Model, usage provider.TokenUsage) (float64, error) {
 	sess, err := a.sessions.Get(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf("failed to get session: %w", err)
+		return 0, fmt.Errorf("failed to get session: %w", err)
 	}
 
 	cost := model.CostPer1MInCached/1e6*float64(usage.CacheCreationTokens) +
@@ -665,9 +675,9 @@ func (a *agent) TrackUsage(ctx context.Context, sessionID string, model catwalk.
 
 	_, err = a.sessions.Save(ctx, sess)
 	if err != nil {
-		return fmt.Errorf("failed to save session: %w", err)
+		return 0, fmt.Errorf("failed to save session: %w", err)
 	}
-	return nil
+	return cost, nil
 }
 
 func (a *agent) Summarize(ctx context.Context, sessionID string) error {

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -104,11 +104,20 @@ type ToolResult struct {
 
 func (ToolResult) isPart() {}
 
+type TokenUsage struct {
+	InputTokens         int64 `json:"input_tokens,omitempty"`
+	OutputTokens        int64 `json:"output_tokens,omitempty"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
+	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
+}
+
 type Finish struct {
 	Reason  FinishReason `json:"reason"`
 	Time    int64        `json:"time"`
 	Message string       `json:"message,omitempty"`
 	Details string       `json:"details,omitempty"`
+	Usage   *TokenUsage  `json:"usage,omitempty"`
+	Cost    float64      `json:"cost,omitempty"`
 }
 
 func (Finish) isPart() {}
@@ -366,7 +375,7 @@ func (m *Message) SetToolResults(tr []ToolResult) {
 	}
 }
 
-func (m *Message) AddFinish(reason FinishReason, message, details string) {
+func (m *Message) AddFinish(reason FinishReason, message, details string, usage *TokenUsage, cost float64) {
 	// remove any existing finish part
 	for i, part := range m.Parts {
 		if _, ok := part.(Finish); ok {
@@ -374,7 +383,7 @@ func (m *Message) AddFinish(reason FinishReason, message, details string) {
 			break
 		}
 	}
-	m.Parts = append(m.Parts, Finish{Reason: reason, Time: time.Now().Unix(), Message: message, Details: details})
+	m.Parts = append(m.Parts, Finish{Reason: reason, Time: time.Now().Unix(), Message: message, Details: details, Usage: usage, Cost: cost})
 }
 
 func (m *Message) AddImageURL(url, detail string) {

--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -395,8 +395,14 @@ func (m *assistantSectionModel) View() string {
 	}
 	modelFormatted := t.S().Muted.Render(model.Name)
 	assistant := fmt.Sprintf("%s %s %s", icon, modelFormatted, infoMsg)
+	var info string
+	if finishData.Usage != nil {
+		usage := finishData.Usage
+		info = fmt.Sprintf("in %d cached %d out %d $%.4f", usage.InputTokens, usage.CacheCreationTokens, usage.OutputTokens, finishData.Cost)
+		info = t.S().Base.Foreground(t.FgSubtle).Render(info)
+	}
 	return t.S().Base.PaddingLeft(2).Render(
-		core.Section(assistant, m.width-2),
+		core.SectionWithInfo(assistant, m.width-2, info),
 	)
 }
 


### PR DESCRIPTION
## Summary
- track token usage and cost on each LLM turn
- show per-turn token counts and cost in chat section headers

## Testing
- `go test ./...` *(fails: Failed to initialize config: failed to load providers)*

------
https://chatgpt.com/codex/tasks/task_e_688d4edf7f6c8332bf6318a1881457d2