### PR TITLE
feat: add responses api as provider type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ncruces/go-sqlite3 v0.25.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nxadm/tail v1.4.11
-	github.com/openai/openai-go v1.11.1
+	github.com/openai/openai-go v1.12.0
 	github.com/pressly/goose/v3 v3.24.2
 	github.com/qjebbs/go-jsons v0.0.0-20221222033332-a534c5fc1c4c
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
-github.com/openai/openai-go v1.11.1 h1:fTQ4Sr9eoRiWFAoHzXiZZpVi6KtLeoTMyGrcOCudjNU=
-github.com/openai/openai-go v1.11.1/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,7 @@ type ProviderConfig struct {
 	// The provider's API endpoint.
 	BaseURL string `json:"base_url,omitempty" jsonschema:"description=Base URL for the provider's API,format=uri,example=https://api.openai.com/v1"`
 	// The provider type, e.g. "openai", "anthropic", etc. if empty it defaults to openai.
-	Type catwalk.Type `json:"type,omitempty" jsonschema:"description=Provider type that determines the API format,enum=openai,enum=anthropic,enum=gemini,enum=azure,enum=vertexai,default=openai"`
+	Type catwalk.Type `json:"type,omitempty" jsonschema:"description=Provider type that determines the API format,enum=openai,enum=openai-responses,enum=anthropic,enum=gemini,enum=azure,enum=vertexai,default=openai"`
 	// The provider's API key.
 	APIKey string `json:"api_key,omitempty" jsonschema:"description=API key for authentication with the provider,example=$OPENAI_API_KEY"`
 	// Marks the provider as disabled.

--- a/internal/llm/provider/openai_responses.go
+++ b/internal/llm/provider/openai_responses.go
@@ -1,0 +1,285 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+)
+
+// openaiResponsesClient implements ProviderClient using the OpenAI Responses API.
+type openaiResponsesClient struct {
+	providerOptions providerClientOptions
+	client          openai.Client
+}
+
+// OpenAIResponsesClient defines the interface for the responses provider.
+type OpenAIResponsesClient ProviderClient
+
+func newOpenAIResponsesClient(opts providerClientOptions) OpenAIResponsesClient {
+	return &openaiResponsesClient{
+		providerOptions: opts,
+		client:          createOpenAIClient(opts),
+	}
+}
+
+func (o *openaiResponsesClient) convertMessages(messages []message.Message) (items []responses.ResponseInputItemUnionParam) {
+	systemMessage := o.providerOptions.systemMessage
+	if o.providerOptions.systemPromptPrefix != "" {
+		systemMessage = o.providerOptions.systemPromptPrefix + "\n" + systemMessage
+	}
+	items = append(items, responses.ResponseInputItemParamOfMessage(systemMessage, responses.EasyInputMessageRoleSystem))
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case message.User:
+			if len(msg.BinaryContent()) == 0 && len(msg.ImageURLContent()) == 0 {
+				items = append(items, responses.ResponseInputItemParamOfMessage(msg.Content().String(), responses.EasyInputMessageRoleUser))
+				continue
+			}
+			contentList := responses.ResponseInputMessageContentListParam{}
+			if text := msg.Content().String(); text != "" {
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputText: &responses.ResponseInputTextParam{Text: text}})
+			}
+			for _, b := range msg.BinaryContent() {
+				img := responses.ResponseInputImageParam{
+					ImageURL: param.NewOpt(b.String(catwalk.InferenceProviderOpenAI)),
+					Detail:   responses.ResponseInputImageDetailAuto,
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputImage: &img})
+			}
+			for _, imgURL := range msg.ImageURLContent() {
+				img := responses.ResponseInputImageParam{
+					ImageURL: param.NewOpt(imgURL.URL),
+					Detail:   responses.ResponseInputImageDetailAuto,
+				}
+				if imgURL.Detail != "" {
+					img.Detail = responses.ResponseInputImageDetail(imgURL.Detail)
+				}
+				contentList = append(contentList, responses.ResponseInputContentUnionParam{OfInputImage: &img})
+			}
+			items = append(items, responses.ResponseInputItemParamOfMessage(contentList, responses.EasyInputMessageRoleUser))
+		case message.Assistant:
+			if text := msg.Content().String(); text != "" {
+				items = append(items, responses.ResponseInputItemParamOfMessage(text, responses.EasyInputMessageRoleAssistant))
+			}
+			for _, call := range msg.ToolCalls() {
+				items = append(items, responses.ResponseInputItemParamOfFunctionCall(call.Input, call.ID, call.Name))
+			}
+		case message.Tool:
+			for _, result := range msg.ToolResults() {
+				items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(result.ToolCallID, result.Content))
+			}
+		}
+	}
+	return
+}
+
+func (o *openaiResponsesClient) convertTools(toolsList []tools.BaseTool) []responses.ToolUnionParam {
+	toolsParams := make([]responses.ToolUnionParam, len(toolsList))
+	for i, t := range toolsList {
+		info := t.Info()
+		fn := responses.FunctionToolParam{
+			Name:        info.Name,
+			Description: param.NewOpt(info.Description),
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": info.Parameters,
+				"required":   info.Required,
+			},
+			Strict: param.NewOpt(true),
+		}
+		toolsParams[i] = responses.ToolUnionParam{OfFunction: &fn}
+	}
+	return toolsParams
+}
+
+func (o *openaiResponsesClient) finishReason(r responses.Response) message.FinishReason {
+	if r.IncompleteDetails.Reason != "" {
+		switch r.IncompleteDetails.Reason {
+		case "max_output_tokens":
+			return message.FinishReasonMaxTokens
+		default:
+			return message.FinishReasonError
+		}
+	}
+	if len(o.toolCalls(r)) > 0 {
+		return message.FinishReasonToolUse
+	}
+	return message.FinishReasonEndTurn
+}
+
+func (o *openaiResponsesClient) preparedParams(messages []responses.ResponseInputItemUnionParam, tools []responses.ToolUnionParam) responses.ResponseNewParams {
+	model := o.providerOptions.model(o.providerOptions.modelType)
+	cfg := config.Get()
+	modelConfig := cfg.Models[config.SelectedModelTypeLarge]
+	if o.providerOptions.modelType == config.SelectedModelTypeSmall {
+		modelConfig = cfg.Models[config.SelectedModelTypeSmall]
+	}
+	reasoningEffort := modelConfig.ReasoningEffort
+
+	params := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(model.ID),
+		Input: responses.ResponseNewParamsInputUnion{OfInputItemList: responses.ResponseInputParam(messages)},
+		Tools: tools,
+	}
+	maxTokens := model.DefaultMaxTokens
+	if modelConfig.MaxTokens > 0 {
+		maxTokens = modelConfig.MaxTokens
+	}
+	if o.providerOptions.maxTokens > 0 {
+		maxTokens = o.providerOptions.maxTokens
+	}
+	params.MaxOutputTokens = param.NewOpt(maxTokens)
+	if model.CanReason {
+		var effort shared.ReasoningEffort
+		switch reasoningEffort {
+		case "low":
+			effort = shared.ReasoningEffortLow
+		case "medium":
+			effort = shared.ReasoningEffortMedium
+		case "high":
+			effort = shared.ReasoningEffortHigh
+		default:
+			effort = shared.ReasoningEffort(reasoningEffort)
+		}
+		params.Reasoning = shared.ReasoningParam{Effort: effort}
+	}
+	return params
+}
+
+func (o *openaiResponsesClient) usage(resp responses.Response) TokenUsage {
+	usage := TokenUsage{
+		InputTokens:  resp.Usage.InputTokens,
+		OutputTokens: resp.Usage.OutputTokens,
+	}
+	usage.CacheReadTokens = resp.Usage.InputTokensDetails.CachedTokens
+	return usage
+}
+
+func (o *openaiResponsesClient) toolCalls(resp responses.Response) []message.ToolCall {
+	var calls []message.ToolCall
+	for _, item := range resp.Output {
+		fc := item.AsFunctionCall()
+		if fc.CallID != "" {
+			calls = append(calls, message.ToolCall{
+				ID:    fc.CallID,
+				Name:  fc.Name,
+				Input: fc.Arguments,
+				Type:  "function",
+			})
+		}
+	}
+	return calls
+}
+
+func (o *openaiResponsesClient) send(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (*ProviderResponse, error) {
+	params := o.preparedParams(o.convertMessages(messages), o.convertTools(tools))
+	attempts := 0
+	for {
+		attempts++
+		resp, err := o.client.Responses.New(ctx, params)
+		if err != nil {
+			retry, after, retryErr := o.shouldRetry(attempts, err)
+			if retryErr != nil {
+				return nil, retryErr
+			}
+			if retry {
+				slog.Warn("Retrying due to rate limit", "attempt", attempts, "max_retries", maxRetries)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(time.Duration(after) * time.Millisecond):
+					continue
+				}
+			}
+			return nil, retryErr
+		}
+		content := resp.OutputText()
+		calls := o.toolCalls(*resp)
+		finish := o.finishReason(*resp)
+		if len(calls) > 0 {
+			finish = message.FinishReasonToolUse
+		}
+		return &ProviderResponse{
+			Content:      content,
+			ToolCalls:    calls,
+			Usage:        o.usage(*resp),
+			FinishReason: finish,
+		}, nil
+	}
+}
+
+func (o *openaiResponsesClient) stream(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan ProviderEvent {
+	eventChan := make(chan ProviderEvent, 2)
+	go func() {
+		defer close(eventChan)
+		resp, err := o.send(ctx, messages, tools)
+		if err != nil {
+			eventChan <- ProviderEvent{Type: EventError, Error: err}
+			return
+		}
+		if resp.Content != "" {
+			eventChan <- ProviderEvent{Type: EventContentDelta, Content: resp.Content}
+		}
+		eventChan <- ProviderEvent{Type: EventComplete, Response: resp}
+	}()
+	return eventChan
+}
+
+func (o *openaiResponsesClient) shouldRetry(attempts int, err error) (bool, int64, error) {
+	if attempts > maxRetries {
+		return false, 0, fmt.Errorf("maximum retry attempts reached for rate limit: %d retries", maxRetries)
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false, 0, err
+	}
+	var apiErr *openai.Error
+	retryMs := 0
+	retryAfterValues := []string{}
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == 401 {
+			o.providerOptions.apiKey, err = config.Get().Resolve(o.providerOptions.config.APIKey)
+			if err != nil {
+				return false, 0, fmt.Errorf("failed to resolve API key: %w", err)
+			}
+			o.client = createOpenAIClient(o.providerOptions)
+			return true, 0, nil
+		}
+		if apiErr.StatusCode != 429 && apiErr.StatusCode != 500 {
+			return false, 0, err
+		}
+		retryAfterValues = apiErr.Response.Header.Values("Retry-After")
+	}
+	if apiErr != nil {
+		slog.Warn("OpenAI API error", "status_code", apiErr.StatusCode, "message", apiErr.Message, "type", apiErr.Type)
+		if len(retryAfterValues) > 0 {
+			slog.Warn("Retry-After header", "values", retryAfterValues)
+		}
+	} else {
+		slog.Error("OpenAI API error", "error", err.Error(), "attempt", attempts, "max_retries", maxRetries)
+	}
+	backoffMs := 2000 * (1 << (attempts - 1))
+	jitterMs := int(float64(backoffMs) * 0.2)
+	retryMs = backoffMs + jitterMs
+	if len(retryAfterValues) > 0 {
+		if _, err := fmt.Sscanf(retryAfterValues[0], "%d", &retryMs); err == nil {
+			retryMs = retryMs * 1000
+		}
+	}
+	return true, int64(retryMs), nil
+}
+
+func (o *openaiResponsesClient) Model() catwalk.Model {
+	return o.providerOptions.model(o.providerOptions.modelType)
+}

--- a/internal/llm/provider/openai_test.go
+++ b/internal/llm/provider/openai_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -17,11 +18,25 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_, err := config.Init(".", true)
+	// Populate provider cache to avoid network calls during config initialization.
+	dir, err := os.MkdirTemp("", "crush-test")
 	if err != nil {
+		panic(err)
+	}
+	os.Setenv("XDG_DATA_HOME", dir)
+	cacheDir := filepath.Join(dir, "crush")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		panic(err)
+	}
+	cacheFile := filepath.Join(cacheDir, "providers.json")
+	// Minimal provider list with OpenAI provider.
+	data := `[{"id":"openai","name":"OpenAI","type":"openai","api_endpoint":"","models":[{"id":"test-model","name":"test-model"}]}]`
+	if err := os.WriteFile(cacheFile, []byte(data), 0o644); err != nil {
+		panic(err)
+	}
+	if _, err := config.Init(".", true); err != nil {
 		panic("Failed to initialize config: " + err.Error())
 	}
-
 	os.Exit(m.Run())
 }
 

--- a/internal/llm/provider/provider.go
+++ b/internal/llm/provider/provider.go
@@ -28,6 +28,9 @@ const (
 	EventWarning        EventType = "warning"
 )
 
+// Custom provider types.
+const TypeOpenAIResponses catwalk.Type = "openai-responses"
+
 type TokenUsage struct {
 	InputTokens         int64
 	OutputTokens        int64
@@ -179,6 +182,11 @@ func NewProvider(cfg config.ProviderConfig, opts ...ProviderClientOption) (Provi
 		return &baseProvider[OpenAIClient]{
 			options: clientOptions,
 			client:  newOpenAIClient(clientOptions),
+		}, nil
+	case TypeOpenAIResponses:
+		return &baseProvider[OpenAIResponsesClient]{
+			options: clientOptions,
+			client:  newOpenAIResponsesClient(clientOptions),
 		}, nil
 	case catwalk.TypeGemini:
 		return &baseProvider[GeminiClient]{

--- a/schema.json
+++ b/schema.json
@@ -286,6 +286,7 @@
           "type": "string",
           "enum": [
             "openai",
+            "openai-responses",
             "anthropic",
             "gemini",
             "azure",


### PR DESCRIPTION
## Summary
- add `openai-responses` provider using OpenAI Responses API
- document new provider type in config schema
- upgrade to `openai-go` v1.12

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d8abd13288332be731f371e05c613